### PR TITLE
Updates READMEs for the cke5 note plugin

### DIFF
--- a/web/modules/custom/cke5_note_plugin/README.md
+++ b/web/modules/custom/cke5_note_plugin/README.md
@@ -1,27 +1,22 @@
-## CKEditor 5 plugin development starter template
+# CKEditor 5 Note (Alert Component) Plugin
 
-To facilitate easier development of modules that provide CKEditor 5 plugins,
-developers may copy the contents of this directory to the root of their module
-directory. This provides the basic build tools and directory structure for
-creating CKEditor 5 plugins within a contributed module, as well as a basic
-working plugin based on the [CKEditor 5 block plugin tutorial](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/tutorials/implementing-a-block-widget.html)
-but with additional documentation and minor changes for better integration
-with Drupal.
+## Overview
 
-When Drupal updates to use newer versions of CKEditor 5, it may be necessary to
-update any files copied from here to your module.
+This plugin allows editors to add preformatted markup for the Alert component
+from the [CMS Design System](https://design.cms.gov).
 
-Plugin source should be added to
-`js/ckeditor5_plugins/{pluginNameDirectory}/src` and the build tools expect this
-directory to include an `index.js` file that exports one or more CKEditor 5
-plugins. Note that requiring `index.js` to be inside
-`{pluginNameDirectory}/src` is not a fixed requirement of CKEditor 5 or Drupal,
-but a requirement of this starter template that can be changed in
-`webpack.config.js` as needed.
+The plugin provides the option to apply three variants of the Alert component:
+Informational, Warning, and Success (all without an icon.)
 
-In the module directory, run `yarn install` to set up the necessary assets. The
-initial run of `install` may take a few minutes, but subsequent builds will be
-faster.
+The component has two fields where basic text elements can be inserted:
+- The Alert heading (ideally an appropriate heading level is used)
+- The Alert body text (typically paragraph text)
 
-After installing dependencies, plugins can be built with `yarn build` or `yarn
-watch`. They will be built to `js/build/{pluginNameDirectory}.js`.  co
+## Setup
+
+This plugin is developed from the working example from the [CKEditor 5 Dev Tools module](https://www.drupal.org/project/ckeditor5_dev), which is based on the [CKEditor 5 block plugin tutorial](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/tutorials/implementing-a-block-widget.html).
+
+In the module directory, run `yarn install` to set up the necessary packages.
+
+After installing dependencies, the plugin can be built with `yarn build` or `yarn
+watch`. It will be built to `js/build/notePlugin.js`.

--- a/web/modules/custom/cke5_note_plugin/js/build/README.txt
+++ b/web/modules/custom/cke5_note_plugin/js/build/README.txt
@@ -1,1 +1,1 @@
-    This is the default destination folder for CKEditor 5 plugin builds.
+This is the default destination folder for CKEditor 5 plugin builds.


### PR DESCRIPTION
Replaces README content with basic details, and removes default migrated from CKE5 dev tools module.